### PR TITLE
Fix decoding alternative keys in AccountMeta

### DIFF
--- a/Sources/SolanaSwift/Models/AccountMeta.swift
+++ b/Sources/SolanaSwift/Models/AccountMeta.swift
@@ -8,14 +8,24 @@ public struct AccountMeta: Equatable, Codable, CustomDebugStringConvertible {
     // MARK: - Decodable
 
     enum CodingKeys: String, CodingKey {
-        case pubkey, signer, writable
+        case pubkey, signer, writable, isSigner, isWritable
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         publicKey = try PublicKey(string: values.decode(String.self, forKey: .pubkey))
-        isSigner = try values.decode(Bool.self, forKey: .signer)
-        isWritable = try values.decode(Bool.self, forKey: .writable)
+
+        do {
+            isSigner = try values.decode(Bool.self, forKey: .signer)
+        } catch {
+            isSigner = try values.decode(Bool.self, forKey: .isSigner)
+        }
+
+        do {
+            isWritable = try values.decode(Bool.self, forKey: .writable)
+        } catch {
+            isWritable = try values.decode(Bool.self, forKey: .isWritable)
+        }
     }
 
     public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
Some dApps like Kamino return different keys for isSigner and isWritable.